### PR TITLE
Feat/change timeout rules

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -150,12 +150,12 @@ NOTE: As a result, the time needed for a match is much greater than the playing 
 ==== Timeouts
 The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
 
-Each team is allocated 3 timeouts at the beginning of the match. A total of 420 seconds is allowed for all timeouts. Timeouts may only be taken during a game
+Each team is allocated 4 timeouts at the beginning of the match. A total of 420 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.
 
-NOTE: For example, a team may take 2 timeouts of 150 seconds duration and thereafter have only one timeout of up to 120 seconds duration.
+NOTE: For example, a team may take 3 timeouts of 110 seconds duration and thereafter have only one timeout of up to 90 seconds duration.
 
-During overtime, both teams can use 1 timeouts with a total time of 240 seconds. The number of timeouts and the time not used in regular game are not added.
+During overtime, both teams can use 2 timeouts with a total time of 240 seconds. The number of timeouts and the time not used in regular game are not added.
 
 No timeouts are possible in the <<Shoot-Out, shoot-out>> stage.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -155,7 +155,7 @@ stoppage. The time is monitored and recorded by the <<Game Controller Operator, 
 
 NOTE: For example, a team may take 2 timeouts of 150 seconds duration and thereafter have only one timeout of up to 120 seconds duration.
 
-During overtime, both teams can use 2 timeouts with a total time of 240 seconds. The number of timeouts and the time not used in regular game are not added.
+During overtime, both teams can use 1 timeouts with a total time of 240 seconds. The number of timeouts and the time not used in regular game are not added.
 
 No timeouts are possible in the <<Shoot-Out, shoot-out>> stage.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -32,7 +32,7 @@ The <<Robot Handler, robot handler>> is the only team member that may talk to th
 * The referee ensures a safe match for all humans and robots
 * The referee ensures a fair match according to the rules of the Small Size League
 * The referee ensures that there is no interference by unauthorized persons or team members
-* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B). Subsequently, the referee resumes the match
+* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> or after every <<Stopping The Game, stoppage>>. Subsequently, the referee resumes the match
 * The referee ensures that the game is started and resumed in time
 
 ==== Assistant Referee
@@ -44,7 +44,7 @@ No team members are allowed to talk to the assistant referee.
 
 * The assistant referee indicates when misconduct or any other incident has occurred out of the view of the referee
 * The assistant referee discusses unclear situations with the referee
-* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B)
+* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> or after every <<Stopping The Game, stoppage>>
 
 
 ==== Game Controller Operator

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -150,12 +150,12 @@ NOTE: As a result, the time needed for a match is much greater than the playing 
 ==== Timeouts
 The <<Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<Autonomy>>).
 
-Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
+Each team is allocated 3 timeouts at the beginning of the match. A total of 420 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.
 
-NOTE: For example, a team may take 3 timeouts of 60 seconds duration and thereafter have only one timeout of up to 120 seconds duration.
+NOTE: For example, a team may take 2 timeouts of 150 seconds duration and thereafter have only one timeout of up to 120 seconds duration.
 
-During overtime, both teams can use 2 timeouts with a total time of 150 seconds. The number of timeouts and the time not used in regular game are not added.
+During overtime, both teams can use 2 timeouts with a total time of 240 seconds. The number of timeouts and the time not used in regular game are not added.
 
 No timeouts are possible in the <<Shoot-Out, shoot-out>> stage.
 

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -32,7 +32,7 @@ The <<Robot Handler, robot handler>> is the only team member that may talk to th
 * The referee ensures a safe match for all humans and robots
 * The referee ensures a fair match according to the rules of the Small Size League
 * The referee ensures that there is no interference by unauthorized persons or team members
-* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> or after every <<Stopping The Game, stoppage>>. Subsequently, the referee resumes the match
+* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B). Subsequently, the referee resumes the match
 * The referee ensures that the game is started and resumed in time
 
 ==== Assistant Referee
@@ -44,7 +44,7 @@ No team members are allowed to talk to the assistant referee.
 
 * The assistant referee indicates when misconduct or any other incident has occurred out of the view of the referee
 * The assistant referee discusses unclear situations with the referee
-* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> or after every <<Stopping The Game, stoppage>>
+* The referee or assistant referee places the ball for <<Kick-Off, kick-offs>> and <<Penalty Kick, penalties>> (division A) or after every <<Stopping The Game, stoppage>> (division B)
 
 
 ==== Game Controller Operator


### PR DESCRIPTION
Com referência a Ata do dia 20/04/2024, segue as alterações feitas para a regra de Timeout:

**- Tempo total de timeouts alterado de 300 para 420 segundos:** Como o EL é uma categoria de entrada e é o primeiro ano de execução, mais tempo de timeout se faz necessário para auxiliar as equipes com eventuais problemas que possam ocorrer
**- Quantidade de timeouts alterada de 4 para 3:** Isso foi discutido para fazer as equipes pensarem mais quando forem realizar um timeout (estrategicamente), para evitar que o jogo pare a todo momento
**- Tempo de timeout no overtime alterado para 240 segundos:** Mesma justificativa do correspondente no tempo normal
**- Quantidade de timeouts no overtime alterado para 1:** Mesma justificativa do correspondente no tempo normal, a partir da discussão em reunião e com os execs