### PR TITLE
Changes dribbler rule text

### DIFF
--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,10 +19,9 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== Dribbling Device
-Observation: The dribbling device will not be allowed in SSL-EL. Robots can have the device, but it will not be allowed activated during the game.
+The dribbling device, present in SSL division B and A, will not be allowed in SSL-EL. Robots can have the device, but it will not be allowed activated during the game.
  
-
-Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:
+Dribbling devices actively exert spin on the ball, which keeps the ball in contact with the robot. They are limited by these conditions:
 
 * The dribbling device must not elevate the ball from the ground
 * Another robot must be able to remove the ball from a robot with the ball.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,6 +19,9 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== Dribbling Device
+Observation: The dribbling device will not be allowed in CBR 2024. For future years, <<Technical Committee, technical committee>> will evaluate the possibility of implementing the dribbling device.
+ 
+
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:
 
 * The dribbling device must not elevate the ball from the ground

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,7 +19,7 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== Dribbling Device
-The dribbling device, present in SSL division B and A, will not be allowed in SSL-EL. Robots can have the device, but it will not be allowed activated during the game.
+The dribbling device present in the Regular League will not be allowed in the SSL-EL. Robots can have the device, but it will not be allowed to be activated during the game.
  
 Dribbling devices actively exert spin on the ball, which keeps the ball in contact with the robot. They are limited by these conditions:
 

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -19,7 +19,7 @@ The <<Referee, referee>> has to force a team to remove a robot from the field if
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== Dribbling Device
-Observation: The dribbling device will not be allowed in CBR 2024. For future years, <<Technical Committee, technical committee>> will evaluate the possibility of implementing the dribbling device.
+Observation: The dribbling device will not be allowed in SSL-EL. Robots can have the device, but it will not be allowed activated during the game.
  
 
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:


### PR DESCRIPTION
Com referência a Ata do dia 20/04/2024, segue as alterações feitas para a regra de Dribbler:

**- Permissão de dispositivo:** Tendo em vista que não será permitido o uso do dispositivo Dribbler na CBR 2024, foi adicionada uma observação que explicita isso no capitulo em que explica o funcionamento dele.