### PR TITLE
adds text about a robot without kicking device entering the opponent area

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -125,7 +125,10 @@ robots' positions, ball speed or any other property that is causing
 the violation before being penalized additional times.
 
 ===== Attacker Touched Ball In Opponent Defense Area
-The ball must not be touched by a robot, while the robot is partially or fully inside the opponent <<Defense Area, defense area>>.
+If the attacking robot touches the ball within the <<Defense Area, defense area>>, it can remain there for 5 seconds after the touch. If this time is exceeded and the robot remains in the area, it will be considered a foul.
+
+NOTE: If the attacking robot pushes the defender into the defensive area, it will not be considered a foul. This situation should be assessed by the human referee or according to <<Crashing>>.
+
 
 ===== Ball Speed
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.


### PR DESCRIPTION
Com referência a Ata do dia 20/04/2024, segue as alterações feitas para a regra do Attacker Touched Ball In Opponent Defense Area: 

- Os robôs poderão tocar na bola e entrar na área de defesa do time adversário, no entanto os mesmos terão um tempo de 5s para entrar na área, realizar a jogada e sair da área. 
- Esse mudança foi realizada com base na decisão de que os robôs do SSL-EL poderão jogar sem módulo de chute, apenas empurrando a bola. afim de minimizar as mudanças no AutoRef e as regras que poderiam surgir caso um caminho diferente fosse seguido. 