### PR TITLE
adds notes about the dribbler device

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -107,16 +107,6 @@ A robot must not kick the ball over the field boundary such that the ball leaves
 The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
-===== Excessive Dribbling
-
-Observation: The Dribbling device will not be allowed in CBR2024. For future years, technical committee will evaluate the possibility of implementing the dribbling device. 
-
-A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
-
-NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.
-
-
-
 ==== Non Stopping Fouls
 Fouls in this section do not cause a <<Stop, stop>>.
 Instead, the game continues normally.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -108,6 +108,9 @@ The ball must not be kept in the <<Defense Area, defense area>> for more than
 5 seconds (Division A) or 10 seconds (Division B).
 
 ===== Excessive Dribbling
+
+Observation: The Dribbling device will not be allowed in CBR2024. For future years, technical committee will evaluate the possibility of implementing the dribbling device. 
+
 A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.
 
 NOTE: Dribblers can still be used to dribble large distances with the ball as long as the robot periodically loses possession, such as kicking the ball ahead of it as human soccer players often do.


### PR DESCRIPTION
Com referência a Ata do dia 20/04/2024, segue as alterações feitas para a regra de Excessive Dribbling:

- **Permissão de dispositivo**: Tendo em vista que não será permitido o uso do dispositivo Dribbler na CBR 2024, foi adicionada uma observação que explicita isso no capitulo em que explica as regras de uso do drible.