### PR TITLE
removes text about the div-A and div-B and sets keeper ball time to 10 s

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -104,8 +104,7 @@ increased.
 A robot must not kick the ball over the field boundary such that the ball leaves the field.
 
 ===== Keeper Held Ball
-The ball must not be kept in the <<Defense Area, defense area>> for more than
-5 seconds (Division A) or 10 seconds (Division B).
+The ball must not be kept in the <<Defense Area, defense area>> for more than 10 seconds.
 
 ===== Excessive Dribbling
 A robot must not <<Dribbling Device, dribble>> the ball further than 1 meter, measured linearly from the ball location where the dribbling started. A robot begins dribbling when it makes contact with the ball and stops dribbling when there is an observable separation between the ball and the robot.


### PR DESCRIPTION
Como as regras são referentes a categoria EL (Entry Level), foram removidos os critérios que divergiam entre Div A e Div B, sendo mantidos apenas os da Div B, que foram os mesmos adotados para o EL. 