### PR TITLE
changes max ball speed to 3 m/s

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -128,7 +128,7 @@ the violation before being penalized additional times.
 The ball must not be touched by a robot, while the robot is partially or fully inside the opponent <<Defense Area, defense area>>.
 
 ===== Ball Speed
-A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
+A robot must not accelerate the ball faster than 3 meters per second in 3D space.
 
 ===== Crashing
 At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.


### PR DESCRIPTION
Com referência a Ata do dia 18/11/2023, segue as alterações feitas para a regra de Ball Speed:

- **Velocidade máxima do chute:** Conforme os ajustes no tamanho do campo e velocidade dos robôs, foi definido que os mesmos não poderão chutar a bola a uma velocidade maior que 3 metros por segundo. 