### PR TITLE
changes speed projection for a robot to commit a foul

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -131,7 +131,7 @@ The ball must not be touched by a robot, while the robot is partially or fully i
 A robot must not accelerate the ball faster than 6.5 meters per second in 3D space.
 
 ===== Crashing
-At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 1.5 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
+At the moment of collision of two robots of different teams, the difference of the speed vectors of both robots is taken and projected onto the line that is defined by the position of both robots. If the length of this projection is greater than 0.75 meters per second, the faster robot committed a foul. If the absolute robot speed difference is less than 0.3 meters per second, both conduct a foul.
 
 
 


### PR DESCRIPTION
Com referência a Ata do dia 18/11/2023 e do dia 20/04/2024, segue as alterações feitas para a regra de Crashing:

- **Redução de velocidade:** Como a velocidade dos robôs foi limitada a 1.5 metros por segundo, a velocidade de colisão também teve que ser reduzida, sendo definida a mesma velocidade de Stop de 0.75 metros por segundo. 