### PR TITLE
removes div-a and div-b mentioning and sets 10 seconds as the not progress time

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -1,6 +1,6 @@
 == Offenses
 === No Progress In Game
-If there is no progress in the game for 5 seconds (Division A) or 10 seconds (Division B) while both teams are allowed to
+If there is no progress in the game for 10 seconds while both teams are allowed to
 <<Ball Manipulation, manipulate the ball>>, the game is <<Stop, stopped>>
 and continued by a <<Force Start, forced start>>.
 


### PR DESCRIPTION
Como as regras são referentes a categoria EL (Entry Level), foram removidos os critérios que divergiam entre Div A e Div B, sendo mantidos apenas os da Div B, que foram os mesmos adotados para o EL.