### PR TITLE
removes text about the double touch in kick-off

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -105,8 +105,6 @@ When the kick-off command is issued, all robots have to move to their own half o
 
 When the <<Normal Start, normal start>> command is issued, the kicker is allowed to shoot the ball. A goal may be scored directly from the kick-off.
 
-When the ball is <<Ball In And Out Of Play, in play>>, the kicker may not touch the ball until it has been touched by another robot or the game has been stopped (see <<Double Touch, double touch>>). Also, the restrictions regarding the robot positions are lifted.
-
 .Usage
 Both half times as well as both overtime periods (if needed) start with a kick-off. Chapter <<Match Preparation>> describes how to determine the attacking team.
 


### PR DESCRIPTION
Com base na ata de 20/04/2024, foi decido remover a restrição do robô tocar na bola no kick-off pois nem todas as equipes possuem um kicker