### PR TITLE
Changes the text about the field limits

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -19,8 +19,7 @@ image::double-size-field.svg[]
 ==== Field Surface
 The playing surface is green felt mat or carpet. The floor under the carpet is level, flat, and hard.
 
-The field surface will continue for 0.5 meters beyond the <<Field Lines, field lines>> on all sides. The outer 0.3 meters of this runoff area, separated from the robot area by a 0.1 meters tall black wall, is used as a designated walking area for the <<Referee, referee>> and the <<Assistant Referee, assistant referee>>. The remaining 0.2 meters are the field margins.
-
+The field surface will continue for 0.5 meters beyond the <<Field Lines, field lines>> on all sides. The field is delimited by a 0.1 meters tall black wall and 0.02 meters wide. The <<Referee, referee>>, the <<Assistant Referee, assistant referee>> and the <<Robot Handler, robot handler>> must be outside of the delimited area while the game is running. 
 
 ==== Field Markings
 The field of play is marked with lines. All lines are 0.01 meters wide and white (paint, spray, white carpet or strong tape). Lines belong to the areas of which they are boundaries.


### PR DESCRIPTION
This PR fixes the text about the field limits considering the image used in the text. In CBR, the field doesn't continue after the black wall, different from the field of RoboCup.